### PR TITLE
REL: R0.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,53 +3,61 @@ FROM centos:7
 LABEL maintainer="K Lauer <klauer@slac.stanford.edu>"
 USER root
 
-# --- Version settings
-ENV BASE_MODULE_TAG           R7.0.2-2.branch
-ENV BASE_MODULE_VERSION       R7.0.2-2.0
-
-ENV ASYN_MODULE_VERSION       R4.35-0.0.1
-ENV AUTOSAVE_MODULE_VERSION   R5.8-2.1.0
-ENV CALC_MODULE_VERSION       R3.7-1.0.1
-ENV ETHERCATMC_MODULE_VERSION R2.1.0-0.1.2
-ENV IOCADMIN_MODULE_VERSION   R3.1.15-1.10.0
-ENV MOTOR_MODULE_VERSION      R6.9-ess-0.0.1
-ENV SEQ_MODULE_VERSION        R2.2.4-1.1
-ENV SSCAN_MODULE_VERSION      R2.10.2-1.0.0
-# --- Version settings
-
 RUN yum install -y epel-release
 
 RUN yum groups mark convert
 RUN yum groupinstall -y 'Development Tools'
 
-RUN yum install -y glibc-common-2.17 telnet perl-CPAN openssl-devel zlib-devel qt5-qtbase-devel
-RUN yum install -y git readline-devel ncurses-devel re2c
+RUN yum install -y \
+        glibc-common-2.17 telnet perl-CPAN openssl-devel zlib-devel \
+        git readline-devel ncurses-devel re2c
+
+# --- Version settings
+ENV BASE_MODULE_TAG           R7.0.2-2.branch
+ENV BASE_MODULE_VERSION       R7.0.2-2.0
+ 
+ENV CALC_MODULE_VERSION       R3.7-1.0.1
+ENV SEQ_MODULE_VERSION        R2.2.4-1.1
+ENV SSCAN_MODULE_VERSION      R2.10.2-1.0.0
+
+ENV ASYN_MODULE_VERSION       R4.35-0.0.1
+ENV AUTOSAVE_MODULE_VERSION   R5.8-2.1.0
+ENV CAPUTLOG_MODULE_VERSION   R3.7-1.0.0
+ENV ETHERCATMC_MODULE_VERSION R2.1.0-0.1.2
+ENV IOCADMIN_MODULE_VERSION   R3.1.15-1.10.0
+ENV MOTOR_MODULE_VERSION      R6.9-ess-0.0.1
+
+# --- Version settings
+
+# Path back-compat
+RUN mkdir -p /reg/g && ln -sf /cds/group/pcds /reg/g/pcds
 
 # -- Set up all git remotes
 ENV GIT_MODULE_TOP https://github.com/slac-epics
 ENV GIT_BASE_TOP   ${GIT_MODULE_TOP}
 
 # -- Set up paths
-ENV EPICS_SITE_TOP            /reg/g/pcds/epics
+ENV EPICS_SITE_TOP            /cds/group/pcds/epics
 
-ENV BASE_MODULE_PATH          /reg/g/pcds/epics/base/${BASE_MODULE_VERSION}
-ENV ASYN_MODULE_PATH          /reg/g/pcds/epics/${BASE_MODULE_VERSION}/modules/asyn/${ASYN_MODULE_VERSION}
-ENV AUTOSAVE_MODULE_PATH      /reg/g/pcds/epics/${BASE_MODULE_VERSION}/modules/autosave/${AUTOSAVE_MODULE_VERSION}
-ENV CALC_MODULE_PATH          /reg/g/pcds/epics/${BASE_MODULE_VERSION}/modules/calc/${CALC_MODULE_VERSION}
-ENV ETHERCATMC_MODULE_PATH    /reg/g/pcds/epics/${BASE_MODULE_VERSION}/modules/ethercatmc/${ETHERCATMC_MODULE_VERSION}
-ENV IOCADMIN_MODULE_PATH      /reg/g/pcds/epics/${BASE_MODULE_VERSION}/modules/iocAdmin/${IOCADMIN_MODULE_VERSION}
-ENV MOTOR_MODULE_PATH         /reg/g/pcds/epics/${BASE_MODULE_VERSION}/modules/motor/${MOTOR_MODULE_VERSION}
-ENV SSCAN_MODULE_PATH         /reg/g/pcds/epics/${BASE_MODULE_VERSION}/modules/sscan/${SSCAN_MODULE_VERSION}
-ENV SEQ_MODULE_PATH           /reg/g/pcds/epics/${BASE_MODULE_VERSION}/modules/seq/${SEQ_MODULE_VERSION}
-ENV IOC_PATH                  /reg/g/pcds/epics/ioc/
+ENV BASE_MODULE_PATH          /cds/group/pcds/epics/base/${BASE_MODULE_VERSION}
+ENV ASYN_MODULE_PATH          /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/asyn/${ASYN_MODULE_VERSION}
+ENV AUTOSAVE_MODULE_PATH      /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/autosave/${AUTOSAVE_MODULE_VERSION}
+ENV CAPUTLOG_MODULE_PATH      /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/caPutLog/${CAPUTLOG_MODULE_VERSION}
+ENV CALC_MODULE_PATH          /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/calc/${CALC_MODULE_VERSION}
+ENV ETHERCATMC_MODULE_PATH    /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/ethercatmc/${ETHERCATMC_MODULE_VERSION}
+ENV IOCADMIN_MODULE_PATH      /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/iocAdmin/${IOCADMIN_MODULE_VERSION}
+ENV MOTOR_MODULE_PATH         /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/motor/${MOTOR_MODULE_VERSION}
+ENV SSCAN_MODULE_PATH         /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/sscan/${SSCAN_MODULE_VERSION}
+ENV SEQ_MODULE_PATH           /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/seq/${SEQ_MODULE_VERSION}
+ENV IOC_PATH                  /cds/group/pcds/epics/ioc/
 ENV IOC_COMMON_PATH           ${IOC_PATH}/common/
 
 ENV EPICS_BASE                      ${BASE_MODULE_PATH}
 ENV EPICS_HOST_ARCH                 rhel7-x86_64
-ENV EPICS_SETUP                     /reg/g/pcds/setup
+ENV EPICS_SETUP                     /cds/group/pcds/setup
 ENV EPICS_CA_REPEATER_PORT          5065
 ENV EPICS_PVA_SERVER_PORT           5075
-ENV EPICS_BASE                      /reg/g/pcds/epics/base/R7.0.2-2.0
+ENV EPICS_BASE                      /cds/group/pcds/epics/base/${BASE_MODULE_VERSION}
 ENV EPICS_PVA_AUTO_ADDR_LIST        YES
 ENV EPICS_CA_AUTO_ADDR_LIST         YES
 ENV EPICS_HOST_ARCH                 rhel7-x86_64
@@ -57,10 +65,10 @@ ENV EPICS_PVA_BROADCAST_PORT        5076
 ENV EPICS_CA_BEACON_PERIOD          15.0
 ENV EPICS_CA_CONN_TMO               30.0
 ENV EPICS_CA_MAX_SEARCH_PERIOD      300
-ENV EPICS_MODULES                   /reg/g/pcds/epics/R7.0.2-2.0/modules
+ENV EPICS_MODULES                   /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules
 ENV EPICS_CA_MAX_ARRAY_BYTES        40000000
 ENV EPICS_CA_SERVER_PORT            5064
-# ENV EPICS_EXTENSIONS                /reg/g/pcds/epics/extensions/R0.2.0
+# ENV EPICS_EXTENSIONS                /cds/group/pcds/epics/extensions/R0.2.0
 # ENV EPICS_REPO                      file:///afs/slac/g/pcds/vol2/svn/pcds
 
 WORKDIR ${EPICS_SITE_TOP}
@@ -77,6 +85,7 @@ RUN git clone --depth 0 --branch ${MOTOR_MODULE_VERSION} -- $GIT_MODULE_TOP/moto
 RUN git clone --depth 0 --branch ${ETHERCATMC_MODULE_VERSION} -- $GIT_MODULE_TOP/ethercatmc.git ${ETHERCATMC_MODULE_PATH}
 RUN git clone --depth 0 --branch ${SSCAN_MODULE_VERSION} -- $GIT_MODULE_TOP/sscan.git ${SSCAN_MODULE_PATH}
 RUN git clone --depth 0 --branch ${SEQ_MODULE_VERSION} -- $GIT_MODULE_TOP/seq.git ${SEQ_MODULE_PATH}
+RUN git clone --depth 0 --branch ${CAPUTLOG_MODULE_VERSION} -- $GIT_MODULE_TOP/caPutLog.git ${CAPUTLOG_MODULE_PATH}
 
 # - Build all of the dependencies
 RUN make -C ${BASE_MODULE_PATH} CROSS_COMPILER_TARGET_ARCHS= all clean
@@ -88,21 +97,22 @@ RUN make -C ${MOTOR_MODULE_PATH} all clean
 
 RUN make -C ${SEQ_MODULE_PATH} RE2C="$(command -v re2c)" all clean
 RUN make -C ${SSCAN_MODULE_PATH} all clean
+RUN make -C ${CAPUTLOG_MODULE_PATH} all clean
 
 # -- Last dependencies most likely to change - ADS + ethercatmc
-ENV ADS_MODULE_VERSION        R2.0.0-0.0.6
+ENV ADS_MODULE_VERSION        R2.0.0-0.0.7
 ENV BECKHOFF_ADS_PATH         /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/modules/ADS.git
-ENV ADS_MODULE_PATH           /reg/g/pcds/epics/${BASE_MODULE_VERSION}/modules/twincat-ads/${ADS_MODULE_VERSION}
+ENV ADS_MODULE_PATH           /cds/group/pcds/epics/${BASE_MODULE_VERSION}/modules/twincat-ads/${ADS_MODULE_VERSION}
 RUN git clone --depth 0 -- $GIT_MODULE_TOP/ADS.git ${BECKHOFF_ADS_PATH}/
 RUN git clone --recursive --depth 0 --branch ${ADS_MODULE_VERSION} -- $GIT_MODULE_TOP/twincat-ads.git ${ADS_MODULE_PATH}
 RUN make -C ${ADS_MODULE_PATH} all clean
 
 WORKDIR ${ETHERCATMC_MODULE_PATH}
-RUN sed -i -e 's/^CALC_MODULE_VERSION.*=.*$/CALC_MODULE_VERSION = R3.7-1.0.1/' configure/RELEASE.local
+RUN sed -i -e 's/^CALC_MODULE_VERSION.*=.*$/CALC_MODULE_VERSION = '${CALC_MODULE_VERSION}/ configure/RELEASE.local
 RUN make -C ${ETHERCATMC_MODULE_PATH} all clean
 
 # - And the ADS IOC
-ENV ADS_IOC_VERSION  R0.2.4
+ENV ADS_IOC_VERSION  R0.6.1
 
 ENV ADS_IOC_ROOT     ${IOC_COMMON_PATH}/ads-ioc
 ENV ADS_IOC_PATH     ${ADS_IOC_ROOT}/${ADS_IOC_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ADS_IOC_VERSION=R0.2.4
+ADS_IOC_VERSION=R0.6.1
 #$(shell git describe --tags)
 
 all: image

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Running an IOC:
 ```sh
 # 
 $ eval $(docker-machine env)
-$ docker run -im pcdshub/ads-ioc:v0.0.1
+$ docker run -im pcdshub/ads-ioc:R0.6.1
 epics>
 ```
 
@@ -14,7 +14,7 @@ Args to be passed to the `adsIoc` binary can be specified after the image name
 above. For example:
 
 ```sh
-$ docker run -im pcdshub/ads-ioc:v0.0.1 st.cmd
+$ docker run -im pcdshub/ads-ioc:R0.6.1 st.cmd
 ```
 
 Updating ads-ioc-docker


### PR DESCRIPTION
## What is this

This bumps to the latest ads-ioc R0.6.1

* What is this? ads-ioc in a docker image; I had used this years ago for initial development but then we switched to conda-based builds specifically for dockerless plcprog-console
* Why not use pib when it already builds ads-ioc in one shot directly and correctly from GitHub ([ref](https://github.com/pcdshub/pib-testing-docker/blob/master/docker/Dockerfile.softIoc))? Well I'm lazy and this was already building the IOC in a slightly more development-friendly way (which maybe indicates pib needs more flexibility)
* Why now? Using this to build ads-ioc for rhel7 and then pushed over to a BSD VM (+ linuxemu) to test ADS library modifications for [local connections](https://github.com/pcdshub/ads-async/pull/40)

## Proof

```
#42 writing image sha256:a02bd4e7f5a5c6b33416fbd1ff1ff872202eb719a86442d732b7708378b1ee3d done
#42 naming to docker.io/pcdshub/ads-ioc:R0.6.1 done
```
It builds, take my hash for it (CI/CD would be nice here, wouldn't it?)